### PR TITLE
Multiple hmap paths in the print command.

### DIFF
--- a/Sources/hmap/Print.swift
+++ b/Sources/hmap/Print.swift
@@ -25,22 +25,32 @@ import Foundation
 import HeaderMapFrontend
 
 func addPrintCommand(to group: Group) {
-  let fileArgument = Argument<String>(
+  let fileArgument = VariadicArgument<String>(
     "file",
-    description: "Path to header map file"
+    description: "Path(s) to header map file"
   )
   
-  group.command("print", fileArgument) { (file) in
-    do {
-      let url = file.expandedFileURL
-      let output = try FilePrintCommand.perform(
-        input: FilePrintCommand.Input(headerMapFile: url, argumentPath: file)
-      )
-      let text = output.text.isEmpty ? "Empty header map" : output.text
-      Swift.print(text)
-    } catch (let error) {
-      Swift.print(error.localizedDescription)
-      exit(ToolReturnCode.failure.rawValue)
+  group.command("print", fileArgument) { (files) in
+    for file in files {
+        if files.count > 1 {
+            Swift.print(file + ":")
+        }
+        
+        do {
+            let url = file.expandedFileURL
+            let output = try FilePrintCommand.perform(
+                input: FilePrintCommand.Input(headerMapFile: url, argumentPath: file)
+            )
+            let text = output.text.isEmpty ? "Empty header map" : output.text
+            Swift.print(text)
+        } catch (let error) {
+            Swift.print(error.localizedDescription)
+            exit(ToolReturnCode.failure.rawValue)
+        }
+        
+        if files.count > 1 {
+            Swift.print("")
+        }
     }
   }
 }

--- a/Sources/hmap/main.swift
+++ b/Sources/hmap/main.swift
@@ -23,7 +23,7 @@
 import Commander
 import HeaderMapFrontend
 
-public let version = "1.0.2"
+public let version = "1.0.3"
 
 let commandGroup = Group()
 addPrintCommand(to: commandGroup)


### PR DESCRIPTION
Hi,

First, thanks for this small map utility. I have used it to investigate some frameworks build issues with Xcode. :-)

This pull request makes it easy to print multiple `hmap` files at once, and typically all `hmap` files in a given directory with a single command like:

````
hmap print *.hmap
````
